### PR TITLE
only make msg.value abstract for payable funcs

### DIFF
--- a/optik/echidna/interface.py
+++ b/optik/echidna/interface.py
@@ -183,8 +183,8 @@ def load_tx(tx: Dict, tx_name: str = "") -> AbstractTx:
     # so we only make an abstract value in that case
     # TODO: consider analyzing if funcs read msg.value
     if int(tx[value_key], 16) != 0:
-        value = Var(256, value_key) 
-        ctx.set(value.name, int(tx["_value"], 16), value.size) 
+        value = Var(256, value_key)
+        ctx.set(value.name, int(tx["_value"], 16), value.size)
     else:
         value = Cst(256, 0)
 

--- a/optik/echidna/interface.py
+++ b/optik/echidna/interface.py
@@ -178,8 +178,15 @@ def load_tx(tx: Dict, tx_name: str = "") -> AbstractTx:
     ctx.set(sender.name, int(tx["_src"], 16), sender.size)
 
     # Translate message value
-    value = Var(256, f"{tx_name}_value")
-    ctx.set(value.name, int(tx["_value"], 16), value.size)
+    value_key = f"{tx_name}_value"
+    # Echidna will only send non-zero msg.value to payable funcs
+    # so we only make an abstract value in that case
+    # TODO: consider analyzing if funcs read msg.value
+    if int(tx[value_key], 16) != 0:
+        value = Var(256, value_key) 
+        ctx.set(value.name, int(tx["_value"], 16), value.size) 
+    else:
+        value = Cst(256, 0)
 
     # Build transaction
     # TODO: make EVMTransaction accept integers as arguments

--- a/optik/echidna/interface.py
+++ b/optik/echidna/interface.py
@@ -181,7 +181,6 @@ def load_tx(tx: Dict, tx_name: str = "") -> AbstractTx:
     value_key = f"{tx_name}_value"
     # Echidna will only send non-zero msg.value to payable funcs
     # so we only make an abstract value in that case
-    # TODO: consider analyzing if funcs read msg.value
     if int(tx[value_key], 16) != 0:
         value = Var(256, value_key)
         ctx.set(value.name, int(tx["_value"], 16), value.size)


### PR DESCRIPTION
IIUC correctly, Echidna gets payable functions from its Slither printer and only sends a non-zero value to payable functions. Thus, when loading the corpus, we can interpret a zero msg.value to mean a function is non-payable instead of re-analyzing with Slither. If a function is non-payable we use a constant value of zero instead of making the value abstract. In the future, we may want to analyze if payable function reads from msg.value and treat is as non-payable if not.

Just a quick sanity check: before this PR, on [Payable.sol](https://github.com/crytic/optik/blob/master/tests/contracts/Payable.sol) generated 207 paths on a fresh run. Now, it generates 139 paths.  

Closes https://github.com/crytic/optik/issues/57