### PR TITLE
Add contributing guideline and black to the CI

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,44 @@
+---
+name: Black
+
+defaults:
+  run:
+    # To load bashrc
+    shell: bash -ieo pipefail {0}
+
+on:
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  build:
+    name: Black
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          pip install .
+
+          mkdir -p .github/linters
+          cp pyproject.toml .github/linters
+
+      - name: Black
+        uses: github/super-linter/slim@v4.9.2
+        if: always()
+        env:
+          # run linter on everything to catch preexisting problems
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Run only black
+          VALIDATE_PYTHON_BLACK: true
+          PYTHON_BLACK_CONFIG_FILE: pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,6 @@ on:
 
 jobs:
   # needs to run only on pull_request
-  lint:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Lint
-      run: |
-        pip install -e .[lint]
-        black --version
-        black --diff --check optik
-
   hybrid-echidna:
     runs-on: ubuntu-20.04
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to optik
+First, thanks for your interest in contributing to optik! We welcome and appreciate all contributions, including bug reports, feature suggestions, tutorials/blog posts, and code improvements.
+
+If you're unsure where to start, we recommend our [`good first issue`](https://github.com/crytic/optik/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/crytic/optik/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issue labels.
+
+## Bug reports and feature suggestions
+Bug reports and feature suggestions can be submitted to our issue tracker. For bug reports, attaching the contract that caused the bug will help us in debugging and resolving the issue quickly. If you find a security vulnerability, do not open an issue; email opensource@trailofbits.com instead.
+
+## Questions
+Questions can be submitted to the issue tracker, but you may get a faster response if you ask in our [chat room](https://empireslacking.herokuapp.com/) (in the #ethereum channel).
+
+## Code
+optik uses the pull request contribution model. Please make an account on Github, fork this repo, and submit code contributions via pull request. For more documentation, look [here](https://guides.github.com/activities/forking/).
+
+Some pull request guidelines:
+
+- Work from the [`dev`](https://github.com/crytic/optik/tree/dev) branch. We perform extensive tests prior to merging anything to `master`, working from `dev` will allow us to merge your work faster.
+- Minimize irrelevant changes (formatting, whitespace, etc) to code that would otherwise not be touched by this patch. Save formatting or style corrections for a separate pull request that does not make any semantic changes.
+- When possible, large changes should be split up into smaller focused pull requests.
+- Fill out the pull request description with a summary of what your patch does, key changes that have been made, and any further points of discussion, if applicable.
+- Title your pull request with a brief description of what it's changing. "Fixes #123" is a good comment to add to the description, but makes for an unclear title on its own.
+- If there are specific operations whose purpose would not be clear to a naive user, documentation should alleviate that.
+- Add type hints to function parameters, return variables, class variables, lists and sets. If possible add type hints to dictionaries.
+
+## Linters
+
+Several linters and security checkers are run on the PRs.
+
+To run them locally:
+
+- `black optik --config pyproject.toml`
+
+We use black `22.3.0`.
+


### PR DESCRIPTION
black is run using the [github super linter](https://github.com/github/super-linter), and use `22.3.0`. This is the same setup that for our other python tools

The contributing guideline mentions multiple linters, which are not yet there, but will be added in other PRs.

I also use the same guidelines regarding `dev` / `master`, and the issues labels that for our other tools - feel free to edit if they don't work here.