### PR TITLE
Update `echidna-test` to `echidna`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fuzzer in _hybrid_ mode. It basically couples Echidna with the [Maat](https://gi
 
 ### Usage
 
-Hybrid echidna can be used seamlessly in place of regular Echidna by replacing `echidna-test` with `hybrid-echidna` in your Echidna command line. 
+Hybrid echidna can be used seamlessly in place of regular Echidna by replacing `echidna` with `hybrid-echidna` in your Echidna command line. 
 For example: 
 
 ```

--- a/optik/echidna/runner.py
+++ b/optik/echidna/runner.py
@@ -246,13 +246,13 @@ def run_echidna_campaign(
     """Run an echidna fuzzing campaign
 
     :param args: arguments to pass to echidna
-    :return: the exit value returned by invoking `echidna-test`
+    :return: the exit value returned by invoking `echidna`
     """
     # Show for how long echidna runs in terminal display
     display.start_echidna_task_timer()
 
     # Build back echidna command line
-    cmdline = ["echidna-test"]
+    cmdline = ["echidna"]
     cmdline += args.FILES
     # Add tx sender(s)
     if args.sender:


### PR DESCRIPTION
Due to the change in the executable name in the [Echidna 2.1.0 Release](https://github.com/crytic/echidna/releases/tag/v2.1.0), hybrid-echidna seems to be broken. 

This PR:
- updates the executable name in the `runner.py`
- updates the Usage section in the docs to reflect the name change